### PR TITLE
Validator and streaming_callback for get_response

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -21,3 +21,5 @@ jobs:
         run: ruff format --check .
       - name: pyright
         run: pyright
+      - name: pytest
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "ruff",
-    "pyright"
+    "pyright",
+    "pytest",
+    "pytest-asyncio"
 ]

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -1,2 +1,3 @@
 from .spice import Spice, SpiceResponse, StreamingSpiceResponse, EmbeddingResponse, TranscriptionResponse  # noqa
 from .spice_message import SpiceMessage, SpiceMessages  # noqa
+from .utils import print_stream  # noqa

--- a/spice/providers.py
+++ b/spice/providers.py
@@ -6,7 +6,7 @@ from typing import Callable, List
 
 from dotenv import load_dotenv
 
-from spice.errors import InvalidProviderError, NoAPIKeyError, SpiceError
+from spice.errors import InvalidProviderError, NoAPIKeyError
 from spice.wrapped_clients import WrappedAnthropicClient, WrappedAzureClient, WrappedClient, WrappedOpenAIClient
 
 # Used to fetch a provider by name

--- a/spice/spice.py
+++ b/spice/spice.py
@@ -17,8 +17,8 @@ from openai.types.chat.completion_create_params import ResponseFormat
 from spice.errors import InvalidModelError, UnknownModelError
 from spice.models import EmbeddingModel, Model, TextModel, TranscriptionModel, get_model_from_name
 from spice.providers import Provider, get_provider_from_name
-from spice.spice_message import MessagesEncoder, SpiceMessage, SpiceMessages
-from spice.utils import embeddings_request_cost, text_request_cost, transcription_request_cost
+from spice.spice_message import MessagesEncoder, SpiceMessage
+from spice.utils import embeddings_request_cost, print_stream, text_request_cost, transcription_request_cost
 from spice.wrapped_clients import WrappedClient
 
 
@@ -59,6 +59,9 @@ class SpiceResponse:
     cost: Optional[float]
     """The cost of this request in cents. May be inaccurate for incompleted streamed responses. Will be None if the cost of the model used is not known."""
 
+    retries: int = 0
+    """The number of retries that were made to get this response. Will be 0 if no retries were made."""
+
     @property
     def total_tokens(self) -> int:
         """The total tokens, input and output, in this response."""
@@ -81,7 +84,8 @@ class StreamingSpiceResponse:
         call_args: SpiceCallArgs,
         client: WrappedClient,
         stream: AsyncIterator,
-        callback: Callable[[SpiceResponse], None],
+        callback: Optional[Callable[[SpiceResponse], None]] = None,
+        streaming_callback: Optional[Callable[[str], None]] = None,
     ):
         self._model = model
         self._call_args = call_args
@@ -94,6 +98,7 @@ class StreamingSpiceResponse:
         self._client = client
         self._stream = stream
         self._callback = callback
+        self._streaming_callback = streaming_callback
 
     def __aiter__(self):
         return self
@@ -109,6 +114,8 @@ class StreamingSpiceResponse:
                         self._input_tokens = input_tokens
                     if output_tokens is not None:
                         self._output_tokens = output_tokens
+                if self._streaming_callback is not None:
+                    self._streaming_callback(content)
                 self._text.append(content)
                 return content
             except StopAsyncIteration:
@@ -143,7 +150,8 @@ class StreamingSpiceResponse:
             self._finished,
             cost,
         )
-        self._callback(response)
+        if self._callback is not None:
+            self._callback(response)
 
         return response
 
@@ -334,6 +342,9 @@ class Spice:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         response_format: Optional[ResponseFormat] = None,
+        validator: Optional[Callable[[str], bool]] = None,
+        streaming_callback: Optional[Callable[[str], None]] = None,
+        retries: int = 0,
     ) -> SpiceResponse:
         """
         Asynchronously retrieves a chat completion response.
@@ -356,24 +367,47 @@ class Spice:
             response_format: For valid models, will set the response format to 'text' or 'json'.
             If the provider/model does not support response_format, this argument will be ignored.
         """
-
-        text_model = self._get_text_model(model)
-        client = self._get_client(text_model, provider)
-        call_args = self._fix_call_args(messages, text_model, False, temperature, max_tokens, response_format)
-
         start_time = timer()
-        with client.catch_and_convert_errors():
-            chat_completion = await client.get_chat_completion_or_stream(call_args)
-        end_time = timer()
-        text, input_tokens, output_tokens = client.extract_text_and_tokens(chat_completion)
+        cost = 0
+        for i in range(retries + 1):
+            text_model = self._get_text_model(model)
+            client = self._get_client(text_model, provider)
+            call_args = self._fix_call_args(
+                messages, text_model, streaming_callback is not None, temperature, max_tokens, response_format
+            )
 
-        cost = text_request_cost(text_model, input_tokens, output_tokens)
-        if cost is not None:
-            self._total_cost += cost
+            with client.catch_and_convert_errors():
+                if streaming_callback is not None:
+                    stream = await client.get_chat_completion_or_stream(call_args)
+                    stream = cast(AsyncIterator, stream)
+                    streaming_spice_response = StreamingSpiceResponse(
+                        text_model, call_args, client, stream, None, streaming_callback
+                    )
+                    chat_completion = await streaming_spice_response.complete_response()
+                    text, input_tokens, output_tokens = (
+                        chat_completion.text,
+                        chat_completion.input_tokens,
+                        chat_completion.output_tokens,
+                    )
 
-        response = SpiceResponse(call_args, text, end_time - start_time, input_tokens, output_tokens, True, cost)
-        self._log_response(response)
-        return response
+                else:
+                    chat_completion = await client.get_chat_completion_or_stream(call_args)
+                    text, input_tokens, output_tokens = client.extract_text_and_tokens(chat_completion)
+
+            completion_cost = text_request_cost(text_model, input_tokens, output_tokens)
+            if completion_cost is not None:
+                cost += completion_cost
+                self._total_cost += completion_cost
+
+            if validator is not None and not validator(text):
+                continue
+            end_time = timer()
+            response = SpiceResponse(
+                call_args, text, end_time - start_time, input_tokens, output_tokens, True, cost, retries=i
+            )
+            self._log_response(response)
+            return response
+        raise ValueError("Failed to get a valid response after all retries")
 
     async def stream_response(
         self,
@@ -383,6 +417,7 @@ class Spice:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         response_format: Optional[ResponseFormat] = None,
+        streaming_callback: Optional[Callable[[str], None]] = None,
     ) -> StreamingSpiceResponse:
         """
         Asynchronously retrieves a chat completion stream that can be iterated over asynchronously.
@@ -420,7 +455,7 @@ class Spice:
                 cache[0] = response.cost
             self._log_response(response)
 
-        return StreamingSpiceResponse(text_model, call_args, client, stream, callback)
+        return StreamingSpiceResponse(text_model, call_args, client, stream, callback, streaming_callback)
 
     def _get_embedding_model(self, model: Optional[Model | str]) -> EmbeddingModel:
         if model is None:

--- a/spice/spice.py
+++ b/spice/spice.py
@@ -382,9 +382,12 @@ class Spice:
             If the provider/model does not support response_format, this argument will be ignored.
 
             name: If given, will be given this name when logged.
+
             validator: If given, will be called with the text of the response. If it returns False, the response will be discarded and another attempt will be made.
+
             streaming_callback: If given, will be called with the text of the response as it is received.
-            retries: The number of times to retry getting a valid response. If 0, will not retry.
+
+            retries: The number of times to retry getting a valid response. If 0, will not retry. If after all retries no valid response is received, will raise a ValueError.
         """
         start_time = timer()
         cost = 0

--- a/spice/utils.py
+++ b/spice/utils.py
@@ -22,3 +22,7 @@ def transcription_request_cost(model: TranscriptionModel, input_length: float) -
         return (model.input_cost * input_length) / 100
     else:
         return None
+
+
+def print_stream(text: str) -> None:
+    print(text, end="", flush=True)

--- a/spice/wrapped_clients.py
+++ b/spice/wrapped_clients.py
@@ -6,7 +6,7 @@ import mimetypes
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncIterator, Collection, ContextManager, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, AsyncIterator, Collection, ContextManager, Dict, List, Optional, Tuple
 
 import anthropic
 import httpx
@@ -19,7 +19,7 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from PIL import Image
 from typing_extensions import override
 
-from spice.errors import APIConnectionError, APIError, AuthenticationError, ImageError, InvalidModelError, SpiceError
+from spice.errors import APIConnectionError, APIError, AuthenticationError, ImageError, InvalidModelError
 from spice.spice_message import VALID_MIMETYPES, SpiceMessage
 
 if TYPE_CHECKING:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,106 @@
+from contextlib import contextmanager
+from pathlib import Path
+from typing import AsyncIterator, Collection, Iterator, List, Optional
+
+from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice as CompletionChoice
+from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
+from typing_extensions import override
+
+from spice.errors import InvalidModelError
+from spice.models import Model
+from spice.spice import SpiceCallArgs
+from spice.spice_message import SpiceMessage
+from spice.wrapped_clients import WrappedClient
+
+
+async def convert_string_to_asynciter(
+    input_str: str,
+    chunk_size: int = 5,
+) -> AsyncIterator[ChatCompletionChunk]:
+    for i in range(0, len(input_str), chunk_size):
+        yield ChatCompletionChunk(
+            id="",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(
+                        content=input_str[i : i + chunk_size],
+                    ),
+                )
+            ],
+            created=0,
+            model="",
+            object="chat.completion.chunk",
+        )
+
+
+class WrappedTestClient(WrappedClient):
+    """
+    A wrapped client that can be used in tests. Accepts what it should respond with in its constructor.
+    """
+
+    def __init__(self, response: str | Iterator[str]):
+        if isinstance(response, str):
+            self.response = iter(response)
+        else:
+            self.response = response
+
+    @override
+    async def get_chat_completion_or_stream(
+        self, call_args: SpiceCallArgs
+    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        response = next(self.response)
+
+        if call_args.stream:
+            return convert_string_to_asynciter(response)
+        else:
+            return ChatCompletion(
+                id="",
+                choices=[
+                    CompletionChoice(
+                        finish_reason="stop",
+                        index=0,
+                        message=ChatCompletionMessage(
+                            content=response,
+                            role="assistant",
+                        ),
+                    )
+                ],
+                created=0,
+                model="",
+                object="chat.completion",
+            )
+
+    @override
+    @contextmanager
+    def catch_and_convert_errors(self):
+        yield
+
+    @override
+    def count_messages_tokens(self, messages: Collection[SpiceMessage], model: Model | str) -> int:
+        return 0
+
+    @override
+    def count_string_tokens(self, message: str, model: Model | str, full_message: bool) -> int:
+        return 0
+
+    @override
+    def process_chunk(self, chunk: ChatCompletionChunk) -> tuple[str, Optional[int], Optional[int]]:
+        return chunk.choices[0].delta.content or "", None, None
+
+    @override
+    def extract_text_and_tokens(self, chat_completion) -> tuple[str, int, int]:
+        return (chat_completion.content[0].text, 0, 0)
+
+    @override
+    async def get_embeddings(self, input_texts: List[str], model: str) -> List[List[float]]:
+        raise InvalidModelError()
+
+    @override
+    def get_embeddings_sync(self, input_texts: List[str], model: str) -> List[List[float]]:
+        raise InvalidModelError()
+
+    @override
+    async def get_transcription(self, audio_path: Path, model: str) -> tuple[str, float]:
+        raise InvalidModelError()

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -1,0 +1,35 @@
+import pytest
+
+from spice import Spice
+from spice.models import HAIKU
+from tests.conftest import WrappedTestClient
+
+
+@pytest.mark.asyncio
+async def test_get_response():
+    client = WrappedTestClient(iter(["Hello, world!", "test"]))
+
+    def equals_test(response):
+        return response == "test"
+
+    validator = equals_test
+
+    spice = Spice()
+
+    def return_wrapped_client(model, provider):
+        return client
+
+    spice._get_client = return_wrapped_client
+    cache = ""
+
+    def accumulator(text: str):
+        nonlocal cache
+        cache += text
+
+    response = await spice.get_response(
+        messages=[], model=HAIKU, validator=validator, streaming_callback=accumulator, retries=2
+    )
+
+    assert response.text == "test"
+    assert response.retries == 1
+    assert cache == "Hello, world!test"


### PR DESCRIPTION
- Validator If you pass a validator get_response will call it on the final string response and retry if it returns false up to retries times. Then it throws an exception. Total costs and retries are returned in the object but only the final passing text is accessible.
- streaming_callback Called incrementally on the chunks. Useful for printing streams. print_stream is provided to reduce boilerplate.

A test for this is added. This is the first test so pytest, pytest_asyncio and WrappedTestClient is added. WrappedTestClient is a convenience WrappedClient which behaves like Openai's wrapped client except you pass in your desired output in the constructor.

Try with:
```
from spice import Spice, print_stream
client = Spice()
await client.get_response([{"role":"user","content":"write a random word"}],
                                             model="gpt-3.5-turbo",
                                             streaming_callback=print_stream,
                                             validator=(lambda x: len(x)%4 == 1),
                                             retries=3)
```