### PR TITLE
Log responses that fail validation

### DIFF
--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -31,5 +31,4 @@ async def test_get_response():
     )
 
     assert response.text == "test"
-    assert response.retries == 1
     assert cache == "Hello, world!test"


### PR DESCRIPTION
Responses are logged with a name appended with their run number. Test with for instance:

```
import asyncio
from spice import Spice, SpiceMessages

client = Spice("gpt-3.5-turbo", logging_dir="tmp")
m = SpiceMessages(client)
m.add_user_message("please list 2 random animals")
v = lambda x: len(x) % 5 == 0
asyncio.run(client.get_response(m, validator=v, retries=3, name="animal_test"))
```