### PR TITLE
Converter added to get_response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages=["spice"]
 
 [project]
 name = "spiceai"
-version = "0.3.7"
+version = "0.3.8"
 license = {text = "Apache-2.0"}
 description = "A Python library for building AI-powered applications."
 readme = "README.md"

--- a/spice/utils.py
+++ b/spice/utils.py
@@ -26,3 +26,7 @@ def transcription_request_cost(model: TranscriptionModel, input_length: float) -
 
 def print_stream(text: str) -> None:
     print(text, end="", flush=True)
+
+
+def string_identity(x: str) -> str:
+    return x

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ class WrappedTestClient(WrappedClient):
 
     @override
     def extract_text_and_tokens(self, chat_completion) -> tuple[str, int, int]:
-        return (chat_completion.content[0].text, 0, 0)
+        return (chat_completion.choices[0].message.content, 0, 0)
 
     @override
     async def get_embeddings(self, input_texts: List[str], model: str) -> List[List[float]]:

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -6,7 +6,7 @@ from tests.conftest import WrappedTestClient
 
 
 @pytest.mark.asyncio
-async def test_get_response():
+async def test_get_response_validator():
     client = WrappedTestClient(iter(["Hello, world!", "test"]))
 
     def equals_test(response):
@@ -20,15 +20,46 @@ async def test_get_response():
         return client
 
     spice._get_client = return_wrapped_client
+
+    response = await spice.get_response(messages=[], model=HAIKU, validator=validator, retries=2)
+
+    assert response.text == "test"
+
+
+@pytest.mark.asyncio
+async def test_streaming_callback():
+    client = WrappedTestClient(iter(["Hello, world!"]))
+
+    spice = Spice()
+
+    def return_wrapped_client(model, provider):
+        return client
+
+    spice._get_client = return_wrapped_client
     cache = ""
 
     def accumulator(text: str):
         nonlocal cache
         cache += text
 
-    response = await spice.get_response(
-        messages=[], model=HAIKU, validator=validator, streaming_callback=accumulator, retries=2
-    )
+    response = await spice.get_response(messages=[], model=HAIKU, streaming_callback=accumulator)
 
-    assert response.text == "test"
-    assert cache == "Hello, world!test"
+    assert response.text == "Hello, world!"
+    assert cache == "Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_get_response_converter():
+    client = WrappedTestClient(iter(["Not an int", "42"]))
+
+    spice = Spice()
+
+    def return_wrapped_client(model, provider):
+        return client
+
+    spice._get_client = return_wrapped_client
+
+    response = await spice.get_response(messages=[], model=HAIKU, converter=int, retries=2)
+
+    assert response.text == "42"
+    assert response.result == 42


### PR DESCRIPTION
Similar to validator a converter can be passed and if so it will be called on output and added to the result field of the SpiceResponse. Example of use:
```
import asyncio
from spice import Spice, print_stream                           
client = Spice()
a = asyncio.run(client.get_response([{"role":"user", "content": "what is your favorite number? Please respond with just one two digit number. This is a test of your ability to follow instructions"}], model="gpt-3.5-turbo", retries=2, streaming_callback=print_stream))
a.text # '42'
a.result # 42
```
I want to use this with pydantic models and their `parse_raw` class method.