### PR TITLE
Anthropic Prompt Caching and more

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages=["spice"]
 
 [project]
 name = "spiceai"
-version = "0.3.20"
+version = "0.4.0"
 license = {text = "Apache-2.0"}
 description = "A Python library for building AI-powered applications."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,6 @@ dev = [
     "ruff",
     "pyright",
     "pytest",
-    "pytest-asyncio"
-    "termcolor"
+    "pytest-asyncio",
+    "termcolor",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,5 @@ dev = [
     "pyright",
     "pytest",
     "pytest-asyncio"
+    "termcolor"
 ]

--- a/scripts/caching.py
+++ b/scripts/caching.py
@@ -1,0 +1,57 @@
+import asyncio
+import os
+import random
+import sys
+
+import requests
+from termcolor import cprint
+
+from spice import Spice
+from spice.models import SONNET_3_5
+from spice.utils import print_stream
+
+# Modify sys.path to ensure the script can run even when it's not part of the installed library.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def display_response_stats(response):
+    cprint(f"Input tokens: {response.input_tokens}", "cyan")
+    cprint(f"Cache Creation Input Tokens: {response.cache_creation_input_tokens}", "cyan")
+    cprint(f"Cache Read Input Tokens: {response.cache_read_input_tokens}", "cyan")
+    cprint(f"Output tokens: {response.output_tokens}", "cyan")
+    cprint(f"Total time: {response.total_time:.2f}s", "green")
+    cprint(f"Cost: ${response.cost / 100:.2f}", "green")
+
+
+async def run(cache: bool):
+    cprint(f"Caching on: {cache}", "cyan")
+    client = Spice()
+    model = SONNET_3_5
+    book_text = requests.get("https://www.gutenberg.org/cache/epub/42671/pg42671.txt").text
+
+    messages = (
+        client.new_messages()
+        .add_system_message(f"Answer questions about a book. Seed:{random.random()}")
+        .add_user_message(f"<book>{book_text}</book>", cache=cache)
+    )
+
+    cprint("First model response:", "green")
+    response = await client.get_response(
+        messages=messages.copy().add_user_message("how many chapters are there? no elaboration."),
+        model=model,
+        streaming_callback=print_stream,
+    )
+    display_response_stats(response)
+
+    cprint("Second model response:", "green")
+    response = await client.get_response(
+        messages=messages.copy().add_user_message("how many volumes are there? no elaboration."),
+        model=model,
+        streaming_callback=print_stream,
+    )
+    display_response_stats(response)
+
+
+if __name__ == "__main__":
+    cache = any(arg in sys.argv for arg in ["--cache", "-c"])
+    asyncio.run(run(cache))

--- a/scripts/caching.py
+++ b/scripts/caching.py
@@ -31,13 +31,13 @@ async def run(cache: bool):
 
     messages = (
         client.new_messages()
-        .add_system_message(f"Answer questions about a book. Seed:{random.random()}")
-        .add_user_message(f"<book>{book_text}</book>", cache=cache)
+        .add_system_text(f"Answer questions about a book. Seed:{random.random()}")
+        .add_user_text(f"<book>{book_text}</book>", cache=cache)
     )
 
     cprint("First model response:", "green")
     response = await client.get_response(
-        messages=messages.copy().add_user_message("how many chapters are there? no elaboration."),
+        messages=messages.copy().add_user_text("how many chapters are there? no elaboration."),
         model=model,
         streaming_callback=print_stream,
     )
@@ -45,7 +45,7 @@ async def run(cache: bool):
 
     cprint("Second model response:", "green")
     response = await client.get_response(
-        messages=messages.copy().add_user_message("how many volumes are there? no elaboration."),
+        messages=messages.copy().add_user_text("how many volumes are there? no elaboration."),
         model=model,
         streaming_callback=print_stream,
     )

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -10,12 +10,16 @@ from spice import Spice
 
 async def basic_example():
     client = Spice()
+    model = "gpt-4o"
 
     messages = client.new_messages()
     messages.add_system_text("You are a helpful assistant.")
     messages.add_user_text("list 5 random words")
 
-    response = await client.get_response(messages=messages, model="gpt-4o")
+    tokens = client.count_prompt_tokens(messages, model=model)
+    print(f"Prompt tokens: {tokens}")
+
+    response = await client.get_response(messages=messages, model=model)
     print(response.text)
 
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -22,6 +22,9 @@ async def basic_example():
     response = await client.get_response(messages=messages, model=model)
     print(response.text)
 
+    json_response = response.model_dump_json(indent=2)
+    print(json_response)
+
 
 async def streaming_example():
     # You can set a default model for the client instead of passing it with each call

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -21,6 +21,21 @@ async def basic_example():
     print(response.text)
 
 
+async def messages_example():
+    client = Spice()
+
+    # message convienence functions
+    messages = (
+        client.new_messages()
+        .add_system_message("You are a helpful assistant.")
+        .add_user_message("list 5 random species of birds")
+    )
+
+    response = await client.get_response(messages=messages, model="gpt-4o")
+
+    print(response.text)
+
+
 async def streaming_example():
     # You can set a default model for the client instead of passing it with each call
     client = Spice(default_text_model="claude-3-opus-20240229")
@@ -120,9 +135,11 @@ async def vision_example():
     print(response.text)
 
     # Alternatively, you can use the SpiceMessages wrapper to easily create your prompts
-    spice_messages: SpiceMessages = SpiceMessages(client)
-    spice_messages.add_user_message("What do you see?")
-    spice_messages.add_file_image_message("~/.mentat/picture.png")
+    spice_messages: SpiceMessages = (
+        SpiceMessages(client)
+        .add_file_image_message("~/.mentat/picture.png")
+        .add_user_message("What do you see? Describe the objects, colors, and style.")
+    )
     response = await client.get_response(spice_messages, CLAUDE_3_OPUS_20240229)
     print(response.text)
 
@@ -155,4 +172,5 @@ async def run_all_examples():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_all_examples())
+    asyncio.run(messages_example())
+    # asyncio.run(run_all_examples())

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -7,13 +7,12 @@ from typing import List
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from spice import Spice
-from spice.spice_message import SpiceMessage
 
 
 async def basic_example():
     client = Spice()
 
-    messages: List[SpiceMessage] = [
+    messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "list 5 random words"},
     ]
@@ -30,8 +29,8 @@ async def streaming_example():
     client.load_prompt("scripts/prompt.txt", name="my prompt")
 
     # Spice can also automatically render Jinja templates.
-    messages: List[SpiceMessage] = [
-        {"role": "system", "content": client.get_rendered_prompt("my prompt", assistant_name="Ryan Reynolds")},
+    messages = [
+        {"role": "system", "content": client.get_rendered_prompt("my prompt", assistant_name="Friendly Robot")},
         {"role": "user", "content": "list 5 random words"},
     ]
     stream = await client.stream_response(messages=messages)
@@ -62,7 +61,7 @@ async def multiple_providers_example():
 
     client = Spice(model_aliases=model_aliases)
 
-    messages: List[SpiceMessage] = [
+    messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "list 5 random words"},
     ]
@@ -86,7 +85,7 @@ async def multiple_providers_example():
 async def azure_example():
     client = Spice()
 
-    messages: List[SpiceMessage] = [
+    messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "list 5 random words"},
     ]
@@ -113,11 +112,11 @@ async def vision_example():
 
     # Spice makes it easy to add images from files or the internet
     from spice import SpiceMessage, SpiceMessages
-    from spice.models import CLAUDE_3_OPUS_20240229, GPT_4_1106_VISION_PREVIEW
+    from spice.models import CLAUDE_3_OPUS_20240229, GPT_4o
     from spice.spice_message import file_image_message, user_message
 
     messages: List[SpiceMessage] = [user_message("What do you see?"), file_image_message("~/.mentat/picture.png")]
-    response = await client.get_response(messages, GPT_4_1106_VISION_PREVIEW)
+    response = await client.get_response(messages, GPT_4o)
     print(response.text)
 
     # Alternatively, you can use the SpiceMessages wrapper to easily create your prompts

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import sys
-from typing import List
 
 # Modify sys.path to ensure the script can run even when it's not part of the installed library.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -12,27 +11,11 @@ from spice import Spice
 async def basic_example():
     client = Spice()
 
-    messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "list 5 random words"},
-    ]
-    response = await client.get_response(messages=messages, model="gpt-4o")
-
-    print(response.text)
-
-
-async def messages_example():
-    client = Spice()
-
-    # message convienence functions
-    messages = (
-        client.new_messages()
-        .add_system_message("You are a helpful assistant.")
-        .add_user_message("list 5 random species of birds")
-    )
+    messages = client.new_messages()
+    messages.add_system_text("You are a helpful assistant.")
+    messages.add_user_text("list 5 random words")
 
     response = await client.get_response(messages=messages, model="gpt-4o")
-
     print(response.text)
 
 
@@ -44,10 +27,10 @@ async def streaming_example():
     client.load_prompt("scripts/prompt.txt", name="my prompt")
 
     # Spice can also automatically render Jinja templates.
-    messages = [
-        {"role": "system", "content": client.get_rendered_prompt("my prompt", assistant_name="Friendly Robot")},
-        {"role": "user", "content": "list 5 random words"},
-    ]
+    messages = client.new_messages()
+    messages.add_system_prompt("my prompt", assistant_name="Friendly Robot")
+    messages.add_user_text("list 5 random words")
+
     stream = await client.stream_response(messages=messages)
 
     async for text in stream:
@@ -76,10 +59,10 @@ async def multiple_providers_example():
 
     client = Spice(model_aliases=model_aliases)
 
-    messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "list 5 random words"},
-    ]
+    messages = client.new_messages()
+    messages.add_system_text("You are a helpful assistant.")
+    messages.add_user_text("list 5 random words")
+
     responses = await asyncio.gather(
         client.get_response(messages=messages, model="task1_model"),
         client.get_response(messages=messages, model="task2_model"),
@@ -100,10 +83,9 @@ async def multiple_providers_example():
 async def azure_example():
     client = Spice()
 
-    messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "list 5 random words"},
-    ]
+    messages = client.new_messages()
+    messages.add_system_text("You are a helpful assistant.")
+    messages.add_user_text("list 5 random words")
 
     # To use Azure, specify the provider and the deployment model name
     response = await client.get_response(messages=messages, model="first-gpt35", provider="azure")
@@ -126,21 +108,20 @@ async def vision_example():
     client = Spice()
 
     # Spice makes it easy to add images from files or the internet
-    from spice import SpiceMessage, SpiceMessages
     from spice.models import CLAUDE_3_OPUS_20240229, GPT_4o
-    from spice.spice_message import file_image_message, user_message
 
-    messages: List[SpiceMessage] = [user_message("What do you see?"), file_image_message("~/.mentat/picture.png")]
+    messages = client.new_messages()
+    messages.add_user_image_from_file("~/.mentat/picture.png")
+    messages.add_user_text("What do you see?")
     response = await client.get_response(messages, GPT_4o)
     print(response.text)
 
-    # Alternatively, you can use the SpiceMessages wrapper to easily create your prompts
-    spice_messages: SpiceMessages = (
-        SpiceMessages(client)
-        .add_file_image_message("~/.mentat/picture.png")
-        .add_user_message("What do you see? Describe the objects, colors, and style.")
+    messages = (
+        client.new_messages()
+        .add_user_image_from_file("~/.mentat/picture.png")
+        .add_user_text("What do you see? Describe the objects, colors, and style.")
     )
-    response = await client.get_response(spice_messages, CLAUDE_3_OPUS_20240229)
+    response = await client.get_response(messages, CLAUDE_3_OPUS_20240229)
     print(response.text)
 
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -153,7 +153,9 @@ async def embeddings_and_transcription_example():
 
     embeddings = await client.get_embeddings(input_texts, TEXT_EMBEDDING_ADA_002)
     transcription = await client.get_transcription("~/.mentat/logs/audio/talk_transcription.wav", WHISPER_1)
+
     print(transcription.text)
+    print(f"{len(embeddings.embeddings)} embeddings fetched for ${(embeddings.cost or 0) / 100:.2f}")
 
 
 async def run_all_examples():
@@ -172,5 +174,4 @@ async def run_all_examples():
 
 
 if __name__ == "__main__":
-    asyncio.run(messages_example())
-    # asyncio.run(run_all_examples())
+    asyncio.run(run_all_examples())

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -2,20 +2,19 @@ import asyncio
 import os
 import sys
 from timeit import default_timer as timer
-from typing import List
 
 from spice.models import SONNET_3_5, GPT_4o_2024_08_06
 
 # Modify sys.path to ensure the script can run even when it's not part of the installed library.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from spice import Spice, SpiceMessage
+from spice import Spice
 
 
 async def speed_compare():
     client = Spice()
 
-    messages: List[SpiceMessage] = [
+    messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "list 100 random words"},
     ]

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -14,10 +14,11 @@ from spice import Spice
 async def speed_compare():
     client = Spice()
 
-    messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "list 100 random words"},
-    ]
+    messages = (
+        client.new_messages()
+        .add_system_message("You are a helpful assistant.")
+        .add_user_message("list 100 random words")
+    )
 
     models = [GPT_4o_2024_08_06, SONNET_3_5]
     runs = 3

--- a/scripts/timing.py
+++ b/scripts/timing.py
@@ -15,9 +15,7 @@ async def speed_compare():
     client = Spice()
 
     messages = (
-        client.new_messages()
-        .add_system_message("You are a helpful assistant.")
-        .add_user_message("list 100 random words")
+        client.new_messages().add_system_text("You are a helpful assistant.").add_user_text("list 100 random words")
     )
 
     models = [GPT_4o_2024_08_06, SONNET_3_5]

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -1,2 +1,3 @@
 from .spice import Spice, SpiceResponse, StreamingSpiceResponse, EmbeddingResponse, TranscriptionResponse  # noqa
 from .utils import print_stream  # noqa
+from .spice_message import SpiceMessages, SpiceMessage  # noqa

--- a/spice/__init__.py
+++ b/spice/__init__.py
@@ -1,3 +1,2 @@
 from .spice import Spice, SpiceResponse, StreamingSpiceResponse, EmbeddingResponse, TranscriptionResponse  # noqa
-from .spice_message import SpiceMessage, SpiceMessages  # noqa
 from .utils import print_stream  # noqa

--- a/spice/call_args.py
+++ b/spice/call_args.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Collection, Optional
+from typing import List, Optional
 
 from openai.types.chat.completion_create_params import ResponseFormat
 
@@ -9,7 +9,7 @@ from spice.spice_message import SpiceMessage
 @dataclass
 class SpiceCallArgs:
     model: str
-    messages: Collection[SpiceMessage]
+    messages: List[SpiceMessage]
     stream: bool = False
     temperature: Optional[float] = None
     max_tokens: Optional[int] = None

--- a/spice/call_args.py
+++ b/spice/call_args.py
@@ -1,13 +1,12 @@
-from dataclasses import dataclass
 from typing import List, Optional
 
 from openai.types.chat.completion_create_params import ResponseFormat
+from pydantic import BaseModel
 
 from spice.spice_message import SpiceMessage
 
 
-@dataclass
-class SpiceCallArgs:
+class SpiceCallArgs(BaseModel):
     model: str
     messages: List[SpiceMessage]
     stream: bool = False

--- a/spice/call_args.py
+++ b/spice/call_args.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Callable, Collection, Dict, Generic, List, Optional, TypeVar, cast
+from dataclasses import dataclass
+from typing import Collection, Optional
 
 from openai.types.chat.completion_create_params import ResponseFormat
 
-from spice.spice_message import MessagesEncoder, SpiceMessage
+from spice.spice_message import SpiceMessage
 
 
 @dataclass

--- a/spice/retry_strategy/__init__.py
+++ b/spice/retry_strategy/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from spice.spice import SpiceCallArgs
 

--- a/spice/retry_strategy/__init__.py
+++ b/spice/retry_strategy/__init__.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Generic, TypeVar
 
-from spice.spice import SpiceCallArgs
+from spice.call_args import SpiceCallArgs
 
 T = TypeVar("T")
 

--- a/spice/retry_strategy/converter_strategy.py
+++ b/spice/retry_strategy/converter_strategy.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 
 from spice.retry_strategy import Behavior, RetryStrategy
 from spice.spice import SpiceCallArgs
-from spice.spice_message import assistant_message, user_message
+from spice.spice_message import SpiceMessages
 
 
 def default_failure_message(message: str) -> str:
@@ -29,9 +29,9 @@ class ConverterStrategy(RetryStrategy):
             return Behavior.RETURN, call_args, result, name
         except Exception as e:
             if attempt_number < self.retries:
-                messages = list(call_args.messages)
-                messages.append(assistant_message(model_output))
-                messages.append(user_message(self.render_failure_message(str(e))))
+                messages = SpiceMessages(messages=call_args.messages)
+                messages.add_assistant_text(model_output)
+                messages.add_user_text(self.render_failure_message(str(e)))
                 call_args = dataclasses.replace(call_args, messages=messages)
                 return Behavior.RETRY, call_args, None, f"{name}-retry-{attempt_number}-fail"
             else:

--- a/spice/retry_strategy/converter_strategy.py
+++ b/spice/retry_strategy/converter_strategy.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from spice.retry_strategy import Behavior, RetryStrategy
 from spice.spice import SpiceCallArgs

--- a/spice/retry_strategy/converter_strategy.py
+++ b/spice/retry_strategy/converter_strategy.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, Callable
 
 from spice.retry_strategy import Behavior, RetryStrategy
@@ -32,7 +31,7 @@ class ConverterStrategy(RetryStrategy):
                 messages = SpiceMessages(messages=call_args.messages)
                 messages.add_assistant_text(model_output)
                 messages.add_user_text(self.render_failure_message(str(e)))
-                call_args = dataclasses.replace(call_args, messages=messages)
-                return Behavior.RETRY, call_args, None, f"{name}-retry-{attempt_number}-fail"
+                new_call_args = call_args.model_copy(update={"messages": messages})
+                return Behavior.RETRY, new_call_args, None, f"{name}-retry-{attempt_number}-fail"
             else:
                 raise ValueError("Failed to get a valid response after all retries")

--- a/spice/retry_strategy/default_strategy.py
+++ b/spice/retry_strategy/default_strategy.py
@@ -1,7 +1,5 @@
 import dataclasses
-from abc import ABC, abstractmethod
-from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional
 
 from spice.retry_strategy import Behavior, RetryStrategy, T
 from spice.spice import SpiceCallArgs

--- a/spice/retry_strategy/default_strategy.py
+++ b/spice/retry_strategy/default_strategy.py
@@ -1,8 +1,8 @@
 import dataclasses
 from typing import Any, Callable, Optional
 
+from spice.call_args import SpiceCallArgs
 from spice.retry_strategy import Behavior, RetryStrategy, T
-from spice.spice import SpiceCallArgs
 
 
 class DefaultRetryStrategy(RetryStrategy):

--- a/spice/retry_strategy/validator_strategy.py
+++ b/spice/retry_strategy/validator_strategy.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Tuple
 
 from spice.call_args import SpiceCallArgs
 from spice.retry_strategy import Behavior, RetryStrategy

--- a/spice/retry_strategy/validator_strategy.py
+++ b/spice/retry_strategy/validator_strategy.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Tuple
 
 from spice.call_args import SpiceCallArgs
 from spice.retry_strategy import Behavior, RetryStrategy
-from spice.spice_message import assistant_message, user_message
+from spice.spice_message import SpiceMessages
 
 
 def default_failure_message(message: str) -> str:
@@ -40,9 +40,9 @@ class ValidatorStrategy(RetryStrategy):
         passed, message = self.validator(model_output)
         if not passed:
             if attempt_number < self.retries:
-                messages = list(call_args.messages)
-                messages.append(assistant_message(model_output))
-                messages.append(user_message(self.render_failure_message(message)))
+                messages = SpiceMessages(messages=call_args.messages)
+                messages.add_assistant_text(model_output)
+                messages.add_user_text(self.render_failure_message(message))
                 call_args = dataclasses.replace(call_args, messages=messages)
                 return Behavior.RETRY, call_args, None, f"{name}-retry-{attempt_number}-fail"
             else:

--- a/spice/retry_strategy/validator_strategy.py
+++ b/spice/retry_strategy/validator_strategy.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, Callable, Tuple
 
 from spice.call_args import SpiceCallArgs
@@ -43,8 +42,8 @@ class ValidatorStrategy(RetryStrategy):
                 messages = SpiceMessages(messages=call_args.messages)
                 messages.add_assistant_text(model_output)
                 messages.add_user_text(self.render_failure_message(message))
-                call_args = dataclasses.replace(call_args, messages=messages)
-                return Behavior.RETRY, call_args, None, f"{name}-retry-{attempt_number}-fail"
+                new_call_args = call_args.model_copy(update={"messages": messages})
+                return Behavior.RETRY, new_call_args, None, f"{name}-retry-{attempt_number}-fail"
             else:
                 raise ValueError("Failed to get a valid response after all retries")
         else:

--- a/spice/spice.py
+++ b/spice/spice.py
@@ -341,7 +341,7 @@ class Spice:
             self._cur_logged_names[base_name] += 1
             response_dict = dataclasses.asdict(response)
             response_dict.pop("_result", "")  # May not be serializable
-            response_json = json.dumps(response_dict, cls=MessagesEncoder)
+            response_json = json.dumps(response_dict)
 
             logging_dir = self.logging_dir / self._cur_run
             logging_dir.mkdir(exist_ok=True, parents=True)

--- a/spice/spice.py
+++ b/spice/spice.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from json import JSONDecodeError
 from pathlib import Path
 from timeit import default_timer as timer
-from typing import Any, AsyncIterator, Callable, Collection, Dict, Generic, List, Optional, TypeVar, cast
+from typing import Any, AsyncIterator, Callable, Collection, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import httpx
 from jinja2 import DictLoader, Environment
@@ -379,7 +379,7 @@ class Spice:
 
     async def get_response(
         self,
-        messages: Collection[SpiceMessage],
+        messages: Collection[Union[SpiceMessage, Dict[str, Any]]],
         model: Optional[TextModel | str] = None,
         provider: Optional[Provider | str] = None,
         temperature: Optional[float] = None,
@@ -432,6 +432,8 @@ class Spice:
             The strategy determines which model responses will be accepted and on an invalid response how the call_args
             will be modified.
         """
+        messages = [SpiceMessage(**message) if isinstance(message, dict) else message for message in messages]
+
         if retry_strategy is None:
             retry_strategy = DefaultRetryStrategy(validator, converter, retries)
 
@@ -485,7 +487,7 @@ class Spice:
 
     async def stream_response(
         self,
-        messages: Collection[SpiceMessage],
+        messages: Collection[Union[SpiceMessage, Dict[str, Any]]],
         model: Optional[TextModel | str] = None,
         provider: Optional[Provider | str] = None,
         temperature: Optional[float] = None,
@@ -518,6 +520,7 @@ class Spice:
 
             name: If given, will be given this name when logged.
         """
+        messages = [SpiceMessage(**message) if isinstance(message, dict) else message for message in messages]
 
         text_model = self._get_text_model(model)
         client = self._get_client(text_model, provider)

--- a/spice/spice.py
+++ b/spice/spice.py
@@ -18,7 +18,6 @@ from typing import (
     List,
     Optional,
     TypeVar,
-    Union,
     cast,
 )
 
@@ -394,7 +393,7 @@ class Spice:
 
     def _fix_call_args(
         self,
-        messages: Union[SpiceMessages, List[SpiceMessage]],
+        messages: List[SpiceMessage],
         model: Model,
         stream: bool,
         temperature: Optional[float],
@@ -406,14 +405,9 @@ class Spice:
             if response_format == {"type": "text"}:
                 response_format = None
 
-        # If messages is a SpiceMessages object, get the data so it can be serialized.
-        # Nothing is lost but the attached client
-        if isinstance(messages, SpiceMessages):
-            messages = messages.data
-
         return SpiceCallArgs(
             model=model.name,
-            messages=messages,
+            messages=list(messages),  # convert from SpiceMessages so we can serialize
             stream=stream,
             temperature=self._default_temperature if temperature is None else temperature,
             max_tokens=max_tokens,
@@ -422,7 +416,7 @@ class Spice:
 
     async def get_response(
         self,
-        messages: Union[SpiceMessages, List[SpiceMessage]],
+        messages: List[SpiceMessage],
         model: Optional[TextModel | str] = None,
         provider: Optional[Provider | str] = None,
         temperature: Optional[float] = None,
@@ -550,7 +544,7 @@ class Spice:
 
     async def stream_response(
         self,
-        messages: Union[SpiceMessages, List[SpiceMessage]],
+        messages: List[SpiceMessage],
         model: Optional[TextModel | str] = None,
         provider: Optional[Provider | str] = None,
         temperature: Optional[float] = None,

--- a/spice/spice.py
+++ b/spice/spice.py
@@ -21,7 +21,7 @@ from spice.models import EmbeddingModel, Model, TextModel, TranscriptionModel, g
 from spice.providers import Provider, get_provider_from_name
 from spice.retry_strategy import Behavior, RetryStrategy
 from spice.retry_strategy.default_strategy import DefaultRetryStrategy
-from spice.spice_message import MessagesEncoder, SpiceMessage
+from spice.spice_message import MessagesEncoder, SpiceMessage, SpiceMessages
 from spice.utils import embeddings_request_cost, string_identity, text_request_cost, transcription_request_cost
 from spice.wrapped_clients import WrappedClient
 
@@ -269,6 +269,12 @@ class Spice:
         self.logging_dir = None if logging_dir is None else Path(logging_dir).expanduser()
         self.logging_callback = logging_callback
         self.new_run("spice")
+
+    def new_messages(self) -> SpiceMessages:
+        """
+        Returns a new SpiceMessages object.
+        """
+        return SpiceMessages(self)
 
     def new_run(self, name: str):
         """

--- a/spice/spice_message.py
+++ b/spice/spice_message.py
@@ -112,63 +112,74 @@ class SpiceMessages(UserList[SpiceMessage]):
         self._client = client
         super().__init__(initlist)
 
-    def add_message(self, role: Literal["user", "assistant", "system"], content: str):
+    def add_message(self, role: Literal["user", "assistant", "system"], content: str) -> SpiceMessages:
         self.data.append(create_message(role, content))
+        return self
 
-    def add_user_message(self, content: str):
+    def add_user_message(self, content: str) -> SpiceMessages:
         """Appends a user message with the given content."""
         self.data.append(user_message(content))
+        return self
 
-    def add_system_message(self, content: str):
+    def add_system_message(self, content: str) -> SpiceMessages:
         """Appends a system message with the given content."""
         self.data.append(system_message(content))
+        return self
 
-    def add_assistant_message(self, content: str):
+    def add_assistant_message(self, content: str) -> SpiceMessages:
         """Appends an assistant message with the given content."""
         self.data.append(assistant_message(content))
+        return self
 
-    def add_image_bytes_message(self, image_bytes: bytes, media_type: str):
+    def add_image_bytes_message(self, image_bytes: bytes, media_type: str) -> SpiceMessages:
         """Appends a user message with the given image bytes."""
         self.data.append(image_bytes_message(image_bytes, media_type))
+        return self
 
-    def add_file_image_message(self, file_path: Path | str):
+    def add_file_image_message(self, file_path: Path | str) -> SpiceMessages:
         """Appends a user message with the image from the given file. The image must be a png, jpg, gif, or webp image."""
         self.data.append(file_image_message(file_path))
+        return self
 
-    def add_http_image_message(self, url: str):
+    def add_http_image_message(self, url: str) -> SpiceMessages:
         """Appends a user message with the image from the given url."""
         self.data.append(http_image_message(url))
+        return self
 
-    def add_prompt(self, role: Literal["user", "assistant", "system"], name: str, **context: Any):
+    def add_prompt(self, role: Literal["user", "assistant", "system"], name: str, **context: Any) -> SpiceMessages:
         prompt = self._client.get_prompt(name)
         rendered_prompt = self._client.get_rendered_prompt(name, **context)
         message = _MetadataDict(create_message(role, rendered_prompt))
         message.prompt_metadata = {"name": name, "content": prompt, "context": context}
         self.data.append(message)  # pyright: ignore
+        return self
 
-    def add_user_prompt(self, name: str, **context: Any):
+    def add_user_prompt(self, name: str, **context: Any) -> SpiceMessages:
         """Appends a user message with the given pre-loaded prompt using jinja to render the context."""
         prompt = self._client.get_prompt(name)
         rendered_prompt = self._client.get_rendered_prompt(name, **context)
         message = _MetadataDict(user_message(rendered_prompt))
         message.prompt_metadata = {"name": name, "content": prompt, "context": context}
         self.data.append(message)  # pyright: ignore
+        return self
 
-    def add_system_prompt(self, name: str, **context: Any):
+    def add_system_prompt(self, name: str, **context: Any) -> SpiceMessages:
         """Appends a system message with the given pre-loaded prompt using jinja to render the context."""
         prompt = self._client.get_prompt(name)
         rendered_prompt = self._client.get_rendered_prompt(name, **context)
         message = _MetadataDict(system_message(rendered_prompt))
         message.prompt_metadata = {"name": name, "content": prompt, "context": context}
         self.data.append(message)  # pyright: ignore
+        return self
 
-    def add_assistant_prompt(self, name: str, **context: Any):
+    def add_assistant_prompt(self, name: str, **context: Any) -> SpiceMessages:
         """Appends a assistant message with the given pre-loaded prompt using jinja to render the context."""
         prompt = self._client.get_prompt(name)
         rendered_prompt = self._client.get_rendered_prompt(name, **context)
         message = _MetadataDict(assistant_message(rendered_prompt))
         message.prompt_metadata = {"name": name, "content": prompt, "context": context}
         self.data.append(message)  # pyright: ignore
+        return self
 
     # Because the constructor has the client as an argument we have to redefine these methods from UserList
     def __getitem__(self, i):  # pyright: ignore

--- a/spice/spice_message.py
+++ b/spice/spice_message.py
@@ -20,15 +20,16 @@ VALID_MIMETYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"]
 class SpiceMessage(BaseModel):
     role: Literal["user", "assistant", "system"]
     content: Union[str, List[Dict[str, Any]]]
+    cache: Optional[bool] = None
 
 
 def create_message(role: Literal["user", "assistant", "system"], content: str) -> SpiceMessage:
     return SpiceMessage(role=role, content=content)
 
 
-def user_message(content: str) -> SpiceMessage:
+def user_message(content: str, cache: bool = False) -> SpiceMessage:
     """Creates a user message with the given content."""
-    return SpiceMessage(role="user", content=content)
+    return SpiceMessage(role="user", content=content, cache=cache)
 
 
 def system_message(content: str) -> SpiceMessage:
@@ -116,9 +117,9 @@ class SpiceMessages(UserList[SpiceMessage]):
         self.data.append(create_message(role, content))
         return self
 
-    def add_user_message(self, content: str) -> SpiceMessages:
+    def add_user_message(self, content: str, cache: bool = False) -> SpiceMessages:
         """Appends a user message with the given content."""
-        self.data.append(user_message(content))
+        self.data.append(user_message(content, cache))
         return self
 
     def add_system_message(self, content: str) -> SpiceMessages:
@@ -204,3 +205,9 @@ class SpiceMessages(UserList[SpiceMessage]):
 
     def __mul__(self, n):
         return self.__class__(self._client, self.data * n)
+
+    def copy(self):
+        return self.__class__(self._client, self.data.copy())
+
+    def __copy__(self):
+        return self.copy()

--- a/spice/spice_message.py
+++ b/spice/spice_message.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import base64
 import mimetypes
-from collections import UserList
-from json import JSONEncoder
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union, get_args
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from spice.errors import ImageError
 
@@ -16,204 +14,119 @@ if TYPE_CHECKING:
 
 VALID_MIMETYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"]
 
-
-class SpiceMessage(BaseModel):
-    role: Literal["user", "assistant", "system"]
-    content: Union[str, List[Dict[str, Any]]]
-    cache: Optional[bool] = None
+Role = Literal["user", "assistant", "system"]
 
 
-def create_message(role: Literal["user", "assistant", "system"], content: str, cache: bool = False) -> SpiceMessage:
-    return SpiceMessage(role=role, content=content, cache=cache)
+class ImageContent(BaseModel):
+    type: Literal["image_url"]
+    image_url: str
 
 
-def user_message(content: str, cache: bool = False) -> SpiceMessage:
-    """Creates a user message with the given content."""
-    return SpiceMessage(role="user", content=content, cache=cache)
+class TextContent(BaseModel):
+    type: Literal["text"]
+    text: str
 
 
-def system_message(content: str, cache: bool = False) -> SpiceMessage:
-    """Creates a system message with the given content."""
-    return SpiceMessage(role="system", content=content, cache=cache)
-
-
-def assistant_message(content: str, cache: bool = False) -> SpiceMessage:
-    """Creates an assistant message with the given content."""
-    return SpiceMessage(role="assistant", content=content, cache=cache)
-
-
-def image_bytes_message(image_bytes: bytes, media_type: str, cache: bool = False) -> SpiceMessage:
-    """Creates a user message containing the given image bytes."""
-    if media_type not in VALID_MIMETYPES:
-        raise ImageError(f"Invalid image type {media_type}: Image must be a png, jpg, gif, or webp image.")
-
-    image = base64.b64encode(image_bytes).decode("utf-8")
-    return SpiceMessage(
-        role="user",
-        content=[{"type": "image_url", "image_url": {"url": f"data:{media_type};base64,{image}"}}],
-        cache=cache,
-    )
-
-
-def file_image_message(file_path: Path | str, cache: bool = False) -> SpiceMessage:
-    """Creates a user message with the image at the given path. The image must be a png, jpg, gif, or webp image."""
-
-    file_path = Path(file_path).expanduser().resolve()
-    if not file_path.exists():
-        raise ImageError(f"Invalid image at {file_path}: file does not exist.")
-
-    media_type = mimetypes.guess_type(file_path)[0]
-    if media_type not in VALID_MIMETYPES:
-        raise ImageError(f"Invalid image at {file_path}: Image must be a png, jpg, gif, or webp image.")
-
-    with file_path.open("rb") as file:
-        image_bytes = file.read()
-
-    return image_bytes_message(image_bytes, media_type, cache=cache)
-
-
-def http_image_message(url: str, cache: bool = False) -> SpiceMessage:
-    """Creates a user message with an image from the given url."""
-    if not (url.startswith("http://") or url.startswith("https://")):
-        raise ImageError(f"Invalid image URL {url}: Must be http or https protocol.")
-
-    return SpiceMessage(role="user", content=[{"type": "image_url", "image_url": {"url": url}}], cache=cache)
-
-
-class MessagesEncoder(JSONEncoder):
-    def default(self, o):
-        if isinstance(o, SpiceMessages):
-            new_data = []
-            for message in o.data:
-                # Shallow copy is ok since we won't be changing anything other than prompt_metadata
-                new_message = message.copy()
-                if hasattr(message, "prompt_metadata"):
-                    new_message["prompt_metadata"] = message.prompt_metadata  # pyright: ignore
-                new_data.append(new_message)
-            return new_data
-        else:
-            return super().default(o)
-
-
-class PromptMetadata(TypedDict):
+class PromptMetadata(BaseModel):
     name: str
     content: str
     context: Dict[str, Any]
 
 
-# Regular dicts can't have arbitrary attributes attached to them
-class _MetadataDict(dict):
-    prompt_metadata: PromptMetadata
+class SpiceMessage(BaseModel):
+    role: Role
+    content: Union[TextContent, ImageContent]
+    cache: bool = Field(default=False)
+    prompt_metadata: Optional[PromptMetadata]
+
+    def __init__(
+        self,
+        role: Role,
+        text: Optional[str] = None,
+        image_url: Optional[str] = None,
+        cache: bool = False,
+        prompt_metadata: Optional[PromptMetadata] = None,
+    ):
+        if text is not None and image_url is not None:
+            raise ValueError("Only one of text or image_url can be provided.")
+        if text is not None:
+            content = TextContent(type="text", text=text)
+        elif image_url is not None:
+            content = ImageContent(type="image_url", image_url=image_url)
+        super().__init__(role=role, content=content, cache=cache, prompt_metadata=prompt_metadata)
+
+    def add_text(self, role: Role, text: str, cache: bool = False) -> SpiceMessages:
+        """Appends a message with the given role and text."""
+        self.data.append(SpiceMessage(role=role, text=text, cache=cache))
+        return self
 
 
-class SpiceMessages(UserList[SpiceMessage]):
-    """
-    A light wrapper around the messages list simplifing adding new messages.
-    """
+def _generate_role_specific_methods(cls):
+    """Generates add_user_text, add_system_text, etc. methods for SpiceMessages."""
+    add_methods = [method for method in dir(cls) if method.startswith("add_")]
 
-    def __init__(self, client: Spice, initlist: Optional[Iterable[SpiceMessage]] = None):
+    def create_method(original, role):
+        def new_method(self, *args, **kwargs):
+            return original(self, role, *args, **kwargs)
+
+        return new_method
+
+    for method_name in add_methods:
+        original_method = getattr(cls, method_name)
+        for role in get_args(Role):
+            new_method_name = f"add_{role}_{method_name[4:]}"
+            setattr(cls, new_method_name, create_method(original_method, role))
+
+    return cls
+
+
+@_generate_role_specific_methods
+class SpiceMessages:
+    """A collection of messages to be sent to an API endpoint."""
+
+    def __init__(self, client: Spice):
         self._client = client
-        super().__init__(initlist)
+        self.data: list[SpiceMessage] = []
 
-    def add_message(
-        self, role: Literal["user", "assistant", "system"], content: str, cache: bool = False
-    ) -> SpiceMessages:
-        self.data.append(create_message(role, content, cache))
+    def add_text(self, role: Role, text: str, cache: bool = False) -> SpiceMessages:
+        """Appends a message with the given role and text."""
+        self.data.append(SpiceMessage(role=role, text=text, cache=cache))
         return self
 
-    def add_user_message(self, content: str, cache: bool = False) -> SpiceMessages:
-        """Appends a user message with the given content."""
-        self.data.append(user_message(content, cache))
+    def add_image_from_url(self, role: Role, url: str, cache: bool = False) -> SpiceMessages:
+        """Appends a message with the given role and image from the given url."""
+        if not (url.startswith("http://") or url.startswith("https://")):
+            raise ImageError(f"Invalid image URL {url}: Must be http or https protocol.")
+        self.data.append(SpiceMessage(role=role, image_url=url, cache=cache))
         return self
 
-    def add_system_message(self, content: str, cache: bool = False) -> SpiceMessages:
-        """Appends a system message with the given content."""
-        self.data.append(system_message(content, cache))
+    def add_image_from_file(self, role: Role, file_path: Path | str, cache: bool = False) -> SpiceMessages:
+        """Appends a message with the given role and image from the given file path."""
+        file_path = Path(file_path).expanduser().resolve()
+        if not file_path.exists():
+            raise ImageError(f"Invalid image at {file_path}: file does not exist.")
+        media_type = mimetypes.guess_type(file_path)[0]
+        if media_type not in VALID_MIMETYPES:
+            raise ImageError(f"Invalid image type {media_type}: Image must be one of {VALID_MIMETYPES}.")
+        with file_path.open("rb") as file:
+            image_bytes = file.read()
+        image = base64.b64encode(image_bytes).decode("utf-8")
+        self.data.append(SpiceMessage(role=role, image_url=f"data:{media_type};base64,{image}", cache=cache))
         return self
 
-    def add_assistant_message(self, content: str, cache: bool = False) -> SpiceMessages:
-        """Appends an assistant message with the given content."""
-        self.data.append(assistant_message(content, cache))
+    def add_prompt(self, role: Role, name: str, cache: bool = False, **context: Any) -> SpiceMessages:
+        """Appends a message with the given role and pre-loaded prompt using jinja to render the context."""
+        self.data.append(
+            SpiceMessage(
+                role=role,
+                text=self._client.get_rendered_prompt(name, **context),
+                cache=cache,
+                prompt_metadata=PromptMetadata(name=name, content=self._client.get_prompt(name), context=context),
+            )
+        )
         return self
-
-    def add_image_bytes_message(self, image_bytes: bytes, media_type: str, cache: bool = False) -> SpiceMessages:
-        """Appends a user message with the given image bytes."""
-        self.data.append(image_bytes_message(image_bytes, media_type, cache))
-        return self
-
-    def add_file_image_message(self, file_path: Path | str, cache: bool = False) -> SpiceMessages:
-        """Appends a user message with the image from the given file. The image must be a png, jpg, gif, or webp image."""
-        self.data.append(file_image_message(file_path, cache))
-        return self
-
-    def add_http_image_message(self, url: str, cache: bool = False) -> SpiceMessages:
-        """Appends a user message with the image from the given url."""
-        self.data.append(http_image_message(url, cache))
-        return self
-
-    def add_prompt(
-        self, role: Literal["user", "assistant", "system"], name: str, cache: bool = False, **context: Any
-    ) -> SpiceMessages:
-        prompt = self._client.get_prompt(name)
-        rendered_prompt = self._client.get_rendered_prompt(name, **context)
-        message = _MetadataDict(create_message(role, rendered_prompt, cache))
-        message.prompt_metadata = {"name": name, "content": prompt, "context": context}
-        self.data.append(message)  # pyright: ignore
-        return self
-
-    def add_user_prompt(self, name: str, cache: bool = False, **context: Any) -> SpiceMessages:
-        """Appends a user message with the given pre-loaded prompt using jinja to render the context."""
-        prompt = self._client.get_prompt(name)
-        rendered_prompt = self._client.get_rendered_prompt(name, **context)
-        message = _MetadataDict(user_message(rendered_prompt, cache))
-        message.prompt_metadata = {"name": name, "content": prompt, "context": context}
-        self.data.append(message)  # pyright: ignore
-        return self
-
-    def add_system_prompt(self, name: str, cache: bool = False, **context: Any) -> SpiceMessages:
-        """Appends a system message with the given pre-loaded prompt using jinja to render the context."""
-        prompt = self._client.get_prompt(name)
-        rendered_prompt = self._client.get_rendered_prompt(name, **context)
-        message = _MetadataDict(system_message(rendered_prompt, cache))
-        message.prompt_metadata = {"name": name, "content": prompt, "context": context}
-        self.data.append(message)  # pyright: ignore
-        return self
-
-    def add_assistant_prompt(self, name: str, cache: bool = False, **context: Any) -> SpiceMessages:
-        """Appends a assistant message with the given pre-loaded prompt using jinja to render the context."""
-        prompt = self._client.get_prompt(name)
-        rendered_prompt = self._client.get_rendered_prompt(name, **context)
-        message = _MetadataDict(assistant_message(rendered_prompt, cache))
-        message.prompt_metadata = {"name": name, "content": prompt, "context": context}
-        self.data.append(message)  # pyright: ignore
-        return self
-
-    # Because the constructor has the client as an argument we have to redefine these methods from UserList
-    def __getitem__(self, i):  # pyright: ignore
-        if isinstance(i, slice):
-            return self.__class__(self._client, self.data[i])
-        else:
-            return self.data[i]
-
-    def __add__(self, other):
-        if isinstance(other, UserList):
-            return self.__class__(self._client, self.data + other.data)
-        elif isinstance(other, type(self.data)):
-            return self.__class__(self._client, self.data + other)
-        return self.__class__(self._client, self.data + list(other))
-
-    def __radd__(self, other):
-        if isinstance(other, UserList):
-            return self.__class__(self._client, other.data + self.data)
-        elif isinstance(other, type(self.data)):
-            return self.__class__(self._client, other + self.data)
-        return self.__class__(self._client, list(other) + self.data)
-
-    def __mul__(self, n):
-        return self.__class__(self._client, self.data * n)
 
     def copy(self):
-        return self.__class__(self._client, self.data.copy())
-
-    def __copy__(self):
-        return self.copy()
+        new_copy = SpiceMessages(self._client)
+        new_copy.data = self.data.copy()
+        return new_copy

--- a/spice/spice_message.py
+++ b/spice/spice_message.py
@@ -4,7 +4,7 @@ import base64
 import mimetypes
 from collections.abc import Collection
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, get_args
 
 from pydantic import BaseModel, Field
 
@@ -79,16 +79,8 @@ def _generate_role_specific_methods(cls):
 
 
 @_generate_role_specific_methods
-class SpiceMessages(Collection[SpiceMessage]):
+class SpiceMessages(List[SpiceMessage]):
     """A collection of messages to be sent to an API endpoint."""
-
-    if TYPE_CHECKING:
-
-        def __getattribute__(self, name: str) -> Any:
-            for role in get_args(Role):
-                if name.startswith(f"add_{role}_"):
-                    _, suffix = name.split(f"{role}_")
-                    return getattr(self, f"add_{suffix}")
 
     def __init__(self, client: Optional[Spice] = None, messages: Collection[SpiceMessage] = []):
         self._client = client
@@ -148,3 +140,11 @@ class SpiceMessages(Collection[SpiceMessage]):
         new_copy = SpiceMessages(self._client)
         new_copy.data = self.data.copy()
         return new_copy
+
+    if TYPE_CHECKING:
+
+        def __getattribute__(self, name: str) -> Any:
+            for role in get_args(Role):
+                if name.startswith(f"add_{role}_"):
+                    _, suffix = name.split(f"{role}_")
+                    return getattr(self, f"add_{suffix}")

--- a/spice/spice_message.py
+++ b/spice/spice_message.py
@@ -138,6 +138,12 @@ class SpiceMessages(Collection[SpiceMessage]):
     def __iter__(self):
         return iter(self.data)
 
+    def __len__(self):
+        return len(self.data)
+
+    def __contains__(self, item):
+        return item in self.data
+
     def copy(self):
         new_copy = SpiceMessages(self._client)
         new_copy.data = self.data.copy()

--- a/spice/utils.py
+++ b/spice/utils.py
@@ -3,9 +3,20 @@ from typing import Optional
 from spice.models import EmbeddingModel, TextModel, TranscriptionModel
 
 
-def text_request_cost(model: TextModel, input_tokens: int, output_tokens: int) -> Optional[float]:
+def text_request_cost(
+    model: TextModel,
+    input_tokens: int,
+    cache_creation_input_tokens: int,
+    cache_read_input_tokens: int,
+    output_tokens: int,
+) -> Optional[float]:
     if model.input_cost is not None and model.output_cost is not None:
-        return (model.input_cost * input_tokens + model.output_cost * output_tokens) / 1_000_000
+        return (
+            model.input_cost * input_tokens
+            + 1.25 * model.input_cost * cache_creation_input_tokens
+            + 0.10 * model.input_cost * cache_read_input_tokens
+            + model.output_cost * output_tokens
+        ) / 1_000_000
     else:
         return None
 

--- a/spice/wrapped_clients.py
+++ b/spice/wrapped_clients.py
@@ -134,6 +134,8 @@ class WrappedOpenAIClient(WrappedClient):
         return TextAndTokens(
             text=chat_completion.choices[0].message.content,
             input_tokens=chat_completion.usage.prompt_tokens,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
             output_tokens=chat_completion.usage.completion_tokens,
         )
 
@@ -311,7 +313,7 @@ class WrappedAnthropicClient(WrappedClient):
                                 if image.startswith("http"):
                                     try:
                                         response = httpx.get(image)
-                                    except:
+                                    except:  # noqa: E722
                                         raise ImageError(f"Error fetching image {image}.")
 
                                     media_type = response.headers.get("content-type", mimetypes.guess_type(image)[0])

--- a/spice/wrapped_clients.py
+++ b/spice/wrapped_clients.py
@@ -328,7 +328,7 @@ class WrappedAnthropicClient(WrappedClient):
                     converted_messages.append({"role": message.role, "content": [block_param]})
 
         if add_json_brace:
-            if converted_messages[-1]["role"] != "assistant":
+            if not converted_messages or converted_messages[-1]["role"] != "assistant":
                 converted_messages.append({"role": "assistant", "content": []})
             converted_messages[-1]["content"].append({"type": "text", "text": "{"})
 

--- a/spice/wrapped_clients.py
+++ b/spice/wrapped_clients.py
@@ -16,7 +16,6 @@ from typing import (
     List,
     Literal,
     Optional,
-    Required,
     Tuple,
     TypedDict,
     Union,
@@ -50,9 +49,9 @@ if TYPE_CHECKING:
 
 
 # a MessageParam with more constrained structure
-class ConstrainedAnthropicMessageParam(TypedDict, total=False):
-    content: Required[List[Union[TextBlockParam, ImageBlockParam]]]
-    role: Required[Literal["user", "assistant"]]
+class ConstrainedAnthropicMessageParam(TypedDict):
+    content: List[Union[TextBlockParam, ImageBlockParam]]
+    role: Literal["user", "assistant"]
 
 
 class TextAndTokens(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,8 @@ class WrappedTestClient(WrappedClient):
         return TextAndTokens(
             text=chunk.choices[0].delta.content or "",
             input_tokens=None,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
             output_tokens=None,
         )
 
@@ -102,6 +104,8 @@ class WrappedTestClient(WrappedClient):
         return TextAndTokens(
             text=chat_completion.choices[0].message.content,
             input_tokens=0,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
             output_tokens=0,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from pathlib import Path
-from typing import AsyncIterator, Collection, Iterator, List, Optional
+from typing import AsyncIterator, Collection, Iterator, List
 
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice as CompletionChoice
@@ -11,7 +11,7 @@ from spice.errors import InvalidModelError
 from spice.models import Model
 from spice.spice import SpiceCallArgs
 from spice.spice_message import SpiceMessage
-from spice.wrapped_clients import WrappedClient
+from spice.wrapped_clients import TextAndTokens, WrappedClient
 
 
 async def convert_string_to_asynciter(
@@ -90,14 +90,20 @@ class WrappedTestClient(WrappedClient):
         return 0
 
     @override
-    def process_chunk(
-        self, chunk: ChatCompletionChunk, call_args: SpiceCallArgs
-    ) -> tuple[str, Optional[int], Optional[int]]:
-        return chunk.choices[0].delta.content or "", None, None
+    def process_chunk(self, chunk: ChatCompletionChunk, call_args: SpiceCallArgs) -> TextAndTokens:
+        return TextAndTokens(
+            text=chunk.choices[0].delta.content or "",
+            input_tokens=None,
+            output_tokens=None,
+        )
 
     @override
-    def extract_text_and_tokens(self, chat_completion, call_args: SpiceCallArgs) -> tuple[str, int, int]:
-        return (chat_completion.choices[0].message.content, 0, 0)
+    def extract_text_and_tokens(self, chat_completion, call_args: SpiceCallArgs) -> TextAndTokens:
+        return TextAndTokens(
+            text=chat_completion.choices[0].message.content,
+            input_tokens=0,
+            output_tokens=0,
+        )
 
     @override
     async def get_embeddings(self, input_texts: List[str], model: str) -> List[List[float]]:

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -87,7 +87,9 @@ async def test_validator_retry_strategy():
     spice._get_client = return_wrapped_client
     response = await spice.get_response(messages=[], model=HAIKU, retry_strategy=retry_strategy)
 
-    last_message = list(client.calls[-1].messages)[-1].content.text
+    content = list(client.calls[-1].messages)[-1].content
+    assert content.type == "text"
+    last_message = content.text
     assert isinstance(last_message, str)
     assert "Failed to validate response for the following reason: You fail!" in last_message
     assert response.text == "Valid response"
@@ -106,7 +108,9 @@ async def test_converter_retry_strategy():
     retry_strategy = ConverterStrategy(converter=int, retries=1)
     response = await spice.get_response(messages=[], model=HAIKU, retry_strategy=retry_strategy)
 
-    last_message = list(client.calls[-1].messages)[-1].content.text
+    content = list(client.calls[-1].messages)[-1].content
+    assert content.type == "text"
+    last_message = content.text
     assert isinstance(last_message, str)
     assert (
         "Failed to convert response for the following reason: invalid literal for int() with base 10: 'Not an int'"

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -87,7 +87,7 @@ async def test_validator_retry_strategy():
     spice._get_client = return_wrapped_client
     response = await spice.get_response(messages=[], model=HAIKU, retry_strategy=retry_strategy)
 
-    last_message = list(client.calls[-1].messages)[-1].get("content")
+    last_message = list(client.calls[-1].messages)[-1].content
     assert isinstance(last_message, str)
     assert "Failed to validate response for the following reason: You fail!" in last_message
     assert response.text == "Valid response"
@@ -106,7 +106,7 @@ async def test_converter_retry_strategy():
     retry_strategy = ConverterStrategy(converter=int, retries=1)
     response = await spice.get_response(messages=[], model=HAIKU, retry_strategy=retry_strategy)
 
-    last_message = list(client.calls[-1].messages)[-1].get("content")
+    last_message = list(client.calls[-1].messages)[-1].content
     assert isinstance(last_message, str)
     assert (
         "Failed to convert response for the following reason: invalid literal for int() with base 10: 'Not an int'"

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -87,7 +87,7 @@ async def test_validator_retry_strategy():
     spice._get_client = return_wrapped_client
     response = await spice.get_response(messages=[], model=HAIKU, retry_strategy=retry_strategy)
 
-    last_message = list(client.calls[-1].messages)[-1].content
+    last_message = list(client.calls[-1].messages)[-1].content.text
     assert isinstance(last_message, str)
     assert "Failed to validate response for the following reason: You fail!" in last_message
     assert response.text == "Valid response"
@@ -106,7 +106,7 @@ async def test_converter_retry_strategy():
     retry_strategy = ConverterStrategy(converter=int, retries=1)
     response = await spice.get_response(messages=[], model=HAIKU, retry_strategy=retry_strategy)
 
-    last_message = list(client.calls[-1].messages)[-1].content
+    last_message = list(client.calls[-1].messages)[-1].content.text
     assert isinstance(last_message, str)
     assert (
         "Failed to convert response for the following reason: invalid literal for int() with base 10: 'Not an int'"


### PR DESCRIPTION
Add support for Anthropic prompt caching. See `scripts/caching.py` for usage

Other things:
- `SpiceMessage` is no longer just `openai.ChatCompletionMessageParam`
- lots of things switched to pydantic
- we now don't auto-convert as much to force things to work with Anthropic - we error instead
- message chaining / get a messages object from client:
```
messages = (
    client.new_messages()
    .add_system_message("You are a helpful assistant.")
    .add_user_message("list 5 random species of birds")
)
```



